### PR TITLE
on_change operational

### DIFF
--- a/apps/grpc_service/lib/server_network.ex
+++ b/apps/grpc_service/lib/server_network.ex
@@ -73,7 +73,7 @@ defmodule Base.NetworkService.Server do
       response = Base.Signals.new(signal: encoded_signals)
       Server.stream_send(stream, response)
     end
-    GRPCSubscriber.start_link(String.to_atom(name), self(), request.signals.signalId, String.to_atom(request.clientId.id), pack_and_send)
+    GRPCSubscriber.start_link(String.to_atom(name), self(), request.signals.signalId, String.to_atom(request.clientId.id), pack_and_send, request.onChange)
     lock_pid(stream)
   end
 

--- a/apps/grpc_service/test/grpc_client_test.exs
+++ b/apps/grpc_service/test/grpc_client_test.exs
@@ -125,12 +125,12 @@ defmodule GRPCClientTest do
     # Logger.info "client end"
   end
 
-  def subscribe_to_signal(signals, namespace, channel) do
+  def subscribe_to_signal(signals, namespace, channel, on_change \\ false) do
     subsignals = Enum.map(signals, fn(signal) ->
       Base.SignalId.new(name: signal, namespace: Base.NameSpace.new(name: namespace))
     end)
     # signal = [Base.SignalId.new(signal_name: signal, namespace: namespace)]
-    request = Base.SubscriberConfig.new(clientId: Base.ClientId.new(id: "grpc-client"), signals: Base.SignalIds.new(signalId: subsignals), onChange: false)
+    request = Base.SubscriberConfig.new(clientId: Base.ClientId.new(id: "grpc-client"), signals: Base.SignalIds.new(signalId: subsignals), onChange: on_change)
     {:ok, stream} = channel |> Base.NetworkService.Stub.subscribe_to_signals(request)
 
     # values = Enum.take(stream, 10)

--- a/apps/grpc_service/test/grpc_service_test.exs
+++ b/apps/grpc_service/test/grpc_service_test.exs
@@ -341,11 +341,67 @@ defmodule GRPCServiceTest do
     # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "WinSwtReqToPass")
     spawn(GRPCClientTest, :subscribe_to_signal, [["WinSwtReqToPass"], @body, GRPCClientTest.setup_connection()])
 
-    :timer.sleep(500)
+    :timer.sleep(2000)
     SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
 
-    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 5}
+    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.namespace.name == @body
+
+    # second signal, same as before
+    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
+
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
+    assert response.payload == {:integer, 5}
+    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.namespace.name == @body
+
+    simple_terminate()
+  end
+
+
+  @tag :this1
+  test "subscribe to signal and make sure it arrives from signal broker onchange active" do
+     simple_initialize()
+
+    # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "WinSwtReqToPass")
+    spawn(GRPCClientTest, :subscribe_to_signal, [["WinSwtReqToPass", "MirrFoldStsAtDrvr"], @body, GRPCClientTest.setup_connection(), true])
+
+    :timer.sleep(2000)
+    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
+
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
+    assert response.payload == {:integer, 5}
+    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.namespace.name == @body
+
+    # second signal, same as before, only the changed should arrive
+    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}, {"MirrFoldStsAtDrvr", 3}], :none, String.to_atom(@body))
+
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
+    assert response.payload == {:integer, 3}
+    assert response.id.name == "MirrFoldStsAtDrvr"
+    assert response.id.namespace.name == @body
+
+    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 6}, {"MirrFoldStsAtDrvr", 3}], :none, String.to_atom(@body))
+
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
+    assert response.payload == {:integer, 6}
+    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.namespace.name == @body
+
+    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 1}, {"MirrFoldStsAtDrvr", 2}], :none, String.to_atom(@body))
+
+    assert_receive {:subscription_received, {:ok, %Base.Signals{signal: signals}}}, 1000
+
+    [response | t] = signals |> Enum.sort()
+    assert response.payload == {:integer, 2}
+    assert response.id.name == "MirrFoldStsAtDrvr"
+    assert response.id.namespace.name == @body
+
+    [response | t] = t
+    assert response.payload == {:integer, 1}
     assert response.id.name == "WinSwtReqToPass"
     assert response.id.namespace.name == @body
 


### PR DESCRIPTION
Fixes #24 which means that https://github.com/volvo-cars/signalbroker-server/blob/master/apps/grpc_service/proto_files/network_api.proto#L16 now behaves as expected.

So signal is emitted to client only when signal value has changed