### PR TITLE
Support for mulitplexed frames 

### DIFF
--- a/apps/payload/lib/dbc.ex
+++ b/apps/payload/lib/dbc.ex
@@ -64,7 +64,7 @@ defmodule DBC do
   # CLIENT
 
   @regex_sg_pre ~r/^\s*SG_\s+/
-  @regex_sg ~r/\s*SG_\s+(\w+)\s*:\s*(\d+)\|(\d+)\@(\d+)([\+\-])\s+\((-?\d*\.?\d+)\s*,\s*(-?\d*\.?\d+)\)\s*\[(-?\d*\.?\d+)\|(-?\d*\.?\d+)\]\s*"(.*)"\s*(.*)/
+  @regex_sg ~r/\s*SG_\s+(\w+\s.*):\s*(\d+)\|(\d+)\@(\d+)([\+\-])\s+\((-?\d*\.?\d+)\s*,\s*(-?\d*\.?\d+)\)\s*\[(-?\d*\.?\d+)\|(-?\d*\.?\d+)\]\s*"(.*)"\s*(.*)/
   @regex_bo_pre ~r/^BO_\s+/
   @regex_bo ~r/^BO_\s+(\d+)\s+(\w+)\s*:\s*(\d+)\s*(\w+)/
   @regex_babo_pre ~r/^BA_\s+\"\w+\"\s+BO_/
@@ -130,7 +130,7 @@ defmodule DBC do
   defp packet_sg([[_, name, startbit, length, _zero, is_signed, factor, offset,
                    margin_lo, margin_hi, unit, tags]]), do:
     %PackInfo{
-      name: name,
+      name: name |> String.trim() |> String.replace(" ", "_"),
       startbit: startbit |> int |> motorola_byte,
       length: int(length),
       is_signed: String.equivalent?("-", is_signed),


### PR DESCRIPTION
As described in the error report the following format causes issues
```
SG_ sensor_name m0 : 23|9@0+ (1,0) [0|500] "cm"
```
cutout from: http://socialledge.com/sjsu/index.php/DBC_Format
```
BO_ 200 SENSOR_SONARS: 8 SENSOR
 SG_ SENSOR_SONARS_mux M : 0|4@1+ (1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_err_count : 4|12@1+ (1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_left m0 : 16|12@1+ (0.1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_middle m0 : 28|12@1+ (0.1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_right m0 : 40|12@1+ (0.1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_rear m0 : 52|12@1+ (0.1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_no_filt_left m1 : 16|12@1+ (0.1,0) [0|0] "" DBG
 SG_ SENSOR_SONARS_no_filt_middle m1 : 28|12@1+ (0.1,0) [0|0] "" DBG
 SG_ SENSOR_SONARS_no_filt_right m1 : 40|12@1+ (0.1,0) [0|0] "" DBG
 SG_ SENSOR_SONARS_no_filt_rear m1 : 52|12@1+ (0.1,0) [0|0] "" DBG
```
line 
> SG_ SENSOR_SONARS_mux **M** : 0|**4**@1+ (1,0) [0|0] "" DRIVER,IO

suggests that signal `SG_ SENSOR_SONARS` is **4** bits which can be used to multiplex where 0 -> m0 and 1 -> m1 up to m15

line 
> SG_ SENSOR_SONARS_left m0 : **16|12**@1+ (0.1,0) [0|0] "" DRIVER,IO
 SG_ SENSOR_SONARS_no_filt_left m1 : **16|12**@1+ (0.1,0) [0|0] "" DBG

is typically two signals **sharing** the same bits, that is: **16|12**

In order for this function properly the client must do the multiplexing. In order to enlighten the user that the signal is muliplexed the **M** (and Mn) is appended to the signals like so:
>SG_ SENSOR_SONARS_mux_**M**
SG_ SENSOR_SONARS_left_**m0**