### PR TITLE
Docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ erl_crash.dump
 # Ignore flexray.dump
 flexray.dump
 
+# Ignore .env file. This file is used to set default envvar for docker-compose
+.env

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To get you started all you need to do is:
   ```shell
   docker-compose up
   ```
-- AND for MacOS: 
+- and for OSX: 
   ```shell
   docker-compose -f docker-compose.macos.yml up
   ```
@@ -90,7 +90,7 @@ However, the preferred way of accessing the system is by using grpc. Follow this
 * grpc_curl, https://github.com/salrashid123/grpc_curl
   
 ## Configuring the server
-The configuration of the server can be done with `configuration/interfaces.json`. This location is the default but if you are using docker-compose you can add an `.env` file to change it. In this case the the configuration folder can be place outside of the repo to avoid adding configuration files by accident. If you add this line to the `.env` file the configuration will be place outside the repository. 
+The configuration of the server can be done with `configuration/interfaces.json`. This location is the default but if you are using docker-compose you can add an `.env` file to change it. In this case the configuration folder can be place outside of the repo to avoid adding configuration files by accident. If you add this line to the `.env` file the configuration will be place outside the repository. 
 ```bash
 CONFIG_FOLDER=../configuration/
 ```
@@ -110,6 +110,26 @@ iex -S mix
 ## Start with **prebuild** images using docker - **recommended**
 
 prebuilt images are available for intel and arm
+
+## to run with docker-compose using .env:
+If you add a file named `.env` with this:
+```bash
+# Custom tag name
+# This tag can be used for version control
+TAG=v1
+
+# This is the IP of the host PC  
+# in the network interface you are using to communicate 
+DOCKER_HOST_IP=127.0.0.1
+
+# Path to the configuration folder 
+# relative to the root of the signalbroker-server
+CONFIG_FOLDER=../configuration/
+
+# Custom command to use template files
+CUSTOM_COMMAND=bash -c "ls /"
+```
+you can change the default values used by docker compose. To read more about "Variable substitution in docker-compose follow [this link](https://docs.docker.com/compose/compose-file/#variable-substitution)
 
 ### to run with your configuration:
 
@@ -145,16 +165,16 @@ docker build -t signalbroker:v1 -f ./docker/Dockerfile .
 ```bash
 docker run --rm -it --privileged=true --net=host -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
 ```
-If you are in MacOS or Windows `--net=host` is not available and you need to do the port mapping:
+If you are in OSX or Windows `--net=host` is not available and you need to do the port mapping:
 ```bash
-docker run --rm -it -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
+docker run -it --network="bridge" -p 127.0.0.1:4040:4040 -p 127.0.0.1:50051:50051 -p 127.0.0.1:2000:2000/udp -p 127.0.0.1:2001:2001/udp -v $PWD/configuration:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
 ```
 
 ### or run it with sample configuration:
 ```bash
 docker run --rm -it --privileged=true --net=host signalbroker:v1
 ```
-If you are in MacOS or Windows `--net=host` is not available and you need to do the port mapping:
+If you are in OSX or Windows `--net=host` is not available and you need to do the port mapping:
 ```bash
 docker run --rm -it -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp signalbroker:v1
 ```

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ To get you started all you need to do is:
     ```shell
     $ cd signalbroker-server
     ```
-- Use docker-compose "up": 
+- Use docker-compose "up" for linux: 
   ```shell
   docker-compose up
+  ```
+- AND for MacOS: 
+  ```shell
+  docker-compose -f docker-compose.macos.yml up
   ```
 
 That's it! Signal Broker will be running after the first build.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ prebuilt images are available for intel and arm
 - Clone this repository (to get the a valid configuration folder), then;
 
 ```bash
-docker run --rm -it --privileged=true --net=host -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration aleksandarf/signalbroker-server:travis-81-amd64
+docker run --rm -it --privileged=true --net=host -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration aleksandarf/signalbroker-server::travis-81-amd64
+```
+If you are in MacOS or Windows `--net=host` is not available and you need to do the port mapping:
+```bash
+docker run --rm -it --privileged=true -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration aleksandarf/signalbroker-server::travis-81-amd64
 ```
 
 ### or run it with sample configuration:
@@ -105,18 +109,23 @@ docker build -t signalbroker:v1 -f ./docker/Dockerfile .
 
 ### to run with your configuration:
 ```bash
-docker run --rm -it --privileged=true --net=host -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
+docker run --rm -it --privileged=true --net=host -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
+```
+If you are in MacOS or Windows `--net=host` is not available and you need to do the port mapping:
+```bash
+docker run --rm -it -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp -v $PWD/configuration/:/signalbroker/_build/prod/rel/signal_server/configuration signalbroker:v1
 ```
 
 ### or run it with sample configuration:
 ```bash
-docker run --rm -it --privileged=true --net=host -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp signalbroker:v1
-
+docker run --rm -it --privileged=true --net=host signalbroker:v1
+```
+If you are in MacOS or Windows `--net=host` is not available and you need to do the port mapping:
+```bash
+docker run --rm -it -p 4040:4040 -p 50051:50051 -p 2000:2000/udp -p 2001:2001/udp signalbroker:v1
 ```
 
-> note 1: mac doesn't have socketcan so you can omit `--net=host`
-
-> note 2: you should be able to do above on intel or arm32/arm64. 
+> you should be able to do above on intel or arm32/arm64. 
 
 ## Playback for off line purposes
 On your Linux computer, install the following.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Documentation is still ongoing, Project is operational out of the box, but custo
 
 keep reading...
 
+## Get started
+
+To get you started all you need to do is:
+- Open a terminal/console window.
+- Clone this repo: 
+    ```shell
+    $ git clone git@github.com:volvo-cars/signalbroker-server.git`
+    ```
+- Move to the new folder: 
+    ```shell
+    $ cd signalbroker-server
+    ```
+- Use docker-compose "up": 
+  ```shell
+  docker-compose up
+  ```
+
+That's it! Signal Broker will be running after the first build.
+
+For more information about:
+- docker-compose follow this [link](https://docs.docker.com/compose/).
+- Other ways to start the server [read this](https://github.com/volvo-cars/signalbroker-server#starting-the-server-for-docker-skip-down).
+- how to configure the server [read this](https://github.com/volvo-cars/signalbroker-server#configuring-the-server)
+
 ## Hardware
 
 The software can execute on any Linux with [SocketCAN](https://en.wikipedia.org/wiki/SocketCAN). On hosts without hardware CAN interfaces, virtual CAN be configured using:
@@ -60,6 +84,12 @@ However, the preferred way of accessing the system is by using grpc. Follow this
 * c code. If you like to use c code [go here](/apps/app_unixds/README.md)
 * websockets, make it play with node [red](https://nodered.org/) or similar, [go here](https://github.com/volvo-cars/signalbroker-web-client)
 * grpc_curl, https://github.com/salrashid123/grpc_curl
+  
+## Configuring the server
+The configuration of the server can be done with `configuration/interfaces.json`. This location is the default but if you are using docker-compose you can add an `.env` file to change it. In this case the the configuration folder can be place outside of the repo to avoid adding configuration files by accident. If you add this line to the `.env` file the configuration will be place outside the repository. 
+```bash
+CONFIG_FOLDER=../configuration/
+```
 
 ## Starting the server (for docker skip down)
 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -24,7 +24,7 @@ services:
       - "${DOCKER_HOST_IP:?Add docker host IP}:2001:2001/udp"
     # # The following lines can be commented out if you don't need a custom configuration 
     # # This volume-mount is only needed if you are going to modify the configuration files
-    # volumes:
+    volumes:
       - "${CONFIG_FOLDER:?Add CONFIG_FOLDER path to your .env file}:/signalbroker/_build/prod/rel/signal_server/configuration"
     # # Use this line only if you need a custom command to be executed by this image
     # # Define the your custom command in the .env file 

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -7,12 +7,16 @@ version: '3.2'
 services:
   signal-broker:
     tty: true
+    # Build and name the SB image
     build:
       context: ./
       dockerfile: docker/Dockerfile
     image: signalbroker:v1
-    # Specify ports only for MacOS and WinOS
+    # Bridge mode for MacOS and WinOS
     network_mode: "bridge"
+    # When bridge mode is used is more reliable to
+    # specify the network interface.
+    # Add DOCKER_HOST_IP=YOUR.IP to an .env file
     ports:
       - "${DOCKER_HOST_IP:?Add docker host IP}:4040:4040"
       - "${DOCKER_HOST_IP:?Add docker host IP}:50051:50051"

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,7 +1,6 @@
-# Author: Alvaro Rodrigo Alonso
-# CDSID: aalonso
 # Created: Dec 3 2019
 # Volvo Car Corporation
+# email: aalonso@volvocars.com
 
 version: '3.2'
 services:

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -14,9 +14,9 @@ services:
     # Specify ports only for MacOS and WinOS
     network_mode: "bridge"
     ports:
-      - "4040:4040"
-      - "50051:50051"
-      - "2000:2000/udp"
-      - "2001:2001/udp"
+      - "${DOCKER_HOST_IP:?Add docker host IP}:4040:4040"
+      - "${DOCKER_HOST_IP:?Add docker host IP}:50051:50051"
+      - "${DOCKER_HOST_IP:?Add docker host IP}:2000:2000/udp"
+      - "${DOCKER_HOST_IP:?Add docker host IP}:2001:2001/udp"
     volumes:
       - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,23 @@
+# Author: Alvaro Rodrigo Alonso
+# CDSID: aalonso
+# Created: Dec 3 2019
+# Volvo Car Corporation
+
+version: '3.2'
+services:
+  signal-broker:
+    stdin_open: true
+    tty: true
+    build:
+      context: ./
+      dockerfile: docker/Dockerfile
+    image: signalbroker:v1
+    # Specify ports only for MacOS and WinOS
+    network_mode: "bridge"
+    ports:
+      - "4040:4040"
+      - "50051:50051"
+      - "2000:2000/udp"
+      - "2001:2001/udp"
+    volumes:
+    - "./configuration/:/signalbroker/_build/prod/rel/signal_server/configuration"

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -20,4 +20,4 @@ services:
       - "2000:2000/udp"
       - "2001:2001/udp"
     volumes:
-    - "./configuration/:/signalbroker/_build/prod/rel/signal_server/configuration"
+      - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -6,7 +6,6 @@
 version: '3.2'
 services:
   signal-broker:
-    stdin_open: true
     tty: true
     build:
       context: ./

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -22,5 +22,10 @@ services:
       - "${DOCKER_HOST_IP:?Add docker host IP}:50051:50051"
       - "${DOCKER_HOST_IP:?Add docker host IP}:2000:2000/udp"
       - "${DOCKER_HOST_IP:?Add docker host IP}:2001:2001/udp"
-    volumes:
-      - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"
+    # # The following lines can be commented out if you don't need a custom configuration 
+    # # This volume-mount is only needed if you are going to modify the configuration files
+    # volumes:
+      - "${CONFIG_FOLDER:?Add CONFIG_FOLDER path to your .env file}:/signalbroker/_build/prod/rel/signal_server/configuration"
+    # # Use this line only if you need a custom command to be executed by this image
+    # # Define the your custom command in the .env file 
+    # command: "${CUSTOM_COMMAND}"

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -10,21 +10,22 @@ services:
     build:
       context: ./
       dockerfile: docker/Dockerfile
-    image: signalbroker:v1
+    image: signalbroker:${TAG:-v1}
     # Bridge mode for MacOS and WinOS
     network_mode: "bridge"
     # When bridge mode is used is more reliable to
     # specify the network interface.
     # Add DOCKER_HOST_IP=YOUR.IP to an .env file
     ports:
-      - "${DOCKER_HOST_IP:?Add docker host IP}:4040:4040"
-      - "${DOCKER_HOST_IP:?Add docker host IP}:50051:50051"
-      - "${DOCKER_HOST_IP:?Add docker host IP}:2000:2000/udp"
-      - "${DOCKER_HOST_IP:?Add docker host IP}:2001:2001/udp"
-    # # The following lines can be commented out if you don't need a custom configuration 
-    # # This volume-mount is only needed if you are going to modify the configuration files
+      - "${DOCKER_HOST_IP:-127.0.0.1}:4040:4040"
+      - "${DOCKER_HOST_IP:-127.0.0.1}:50051:50051"
+      - "${DOCKER_HOST_IP:-127.0.0.1}:2000:2000/udp"
+      - "${DOCKER_HOST_IP:-127.0.0.1}:2001:2001/udp"
+    # # Mount the "configuration" folder as a volume to be make changes in the files
+    # # without having to re-build the docker image every time
+    # # Add CONFIG_FOLDER=../configuration_path to an .env file  
     volumes:
-      - "${CONFIG_FOLDER:?Add CONFIG_FOLDER path to your .env file}:/signalbroker/_build/prod/rel/signal_server/configuration"
+      - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"
     # # Use this line only if you need a custom command to be executed by this image
     # # Define the your custom command in the .env file 
     # command: "${CUSTOM_COMMAND}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# Author: Alvaro Rodrigo Alonso
+# CDSID: aalonso
+# Created: Dec 3 2019
+# Volvo Car Corporation
+
+version: '3.2'
+services:
+  signal-broker:
+    stdin_open: true
+    tty: true
+    build:
+      context: ./
+      dockerfile: docker/Dockerfile
+    image: signalbroker:v1
+    # Network mode only available in Linux
+    network_mode: "host"
+    volumes:
+    - "./configuration/:/signalbroker/_build/prod/rel/signal_server/configuration"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
     # Network mode only available in Linux
     network_mode: "host"
     volumes:
-    - "./configuration/:/signalbroker/_build/prod/rel/signal_server/configuration"
+    - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-# Author: Alvaro Rodrigo Alonso
-# CDSID: aalonso
 # Created: Dec 3 2019
 # Volvo Car Corporation
+# email: aalonso@volvocars.com
 
 version: '3.2'
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,18 @@
 version: '3.2'
 services:
   signal-broker:
-    stdin_open: true
     tty: true
+    ## Build and name the SB image
     build:
       context: ./
       dockerfile: docker/Dockerfile
     image: signalbroker:v1
-    # Network mode only available in Linux
+    ## Network mode only available in Linux
     network_mode: "host"
-    volumes:
-    - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"
+    # # The following lines can be commented out if you need a custom configuration 
+    # # This volume-mount is needed if you are going to modify the configuration files
+    # volumes:
+    #  - "${CONFIG_FOLDER:?Add CONFIG_FOLDER path to your .env file}:/signalbroker/_build/prod/rel/signal_server/configuration"
+    # # Use this line only if you need a custom command to be executed by this image
+    # # Define the your custom command in the .env file 
+    # command: "${CUSTOM_COMMAND}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,14 @@ services:
     build:
       context: ./
       dockerfile: docker/Dockerfile
-    image: signalbroker:v1
+    image: signalbroker:${TAG:-v1}
     ## Network mode only available in Linux
     network_mode: "host"
-    # # The following lines can be commented out if you need a custom configuration 
-    # # This volume-mount is needed if you are going to modify the configuration files
-    # volumes:
-    #  - "${CONFIG_FOLDER:?Add CONFIG_FOLDER path to your .env file}:/signalbroker/_build/prod/rel/signal_server/configuration"
+    # # Mount the "configuration" folder as a volume to be make changes in the files
+    # # without having to re-build the docker image every time
+    # # Add CONFIG_FOLDER=../configuration_path to an .env file  
+    volumes:
+    - "${CONFIG_FOLDER:-./configuration}:/signalbroker/_build/prod/rel/signal_server/configuration"
     # # Use this line only if you need a custom command to be executed by this image
     # # Define the your custom command in the .env file 
     # command: "${CUSTOM_COMMAND}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,10 @@ ARG MIX_ENV=prod
 RUN mix local.hex --force
 RUN mix local.rebar --force
 
-COPY . /signalbroker/
+COPY mix.exs mix.lock /signalbroker/
+COPY apps /signalbroker/apps
+COPY config /signalbroker/config
+COPY rel /signalbroker/rel
 WORKDIR /signalbroker
 RUN rm -rf _build
 RUN rm -rf deps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update \
                apt-transport-https \
                iproute2 can-utils \
                vim tmux \
-               build-essential git make gcc cmake cmake-curses-gui \
-               gettext
+               build-essential git make gcc cmake cmake-curses-gui
 
 ENV LANG en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
@@ -44,7 +43,6 @@ RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
 
 WORKDIR /signalbroker/_build/prod/rel/signal_server
 COPY --from=build-env signalbroker/_build /signalbroker/_build/
-COPY --from=build-env /usr/bin/envsubst /usr/bin/envsubst
 COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
 ENV SIGNAL_SERVER /signalbroker/_build/prod/rel/signal_server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update \
                apt-transport-https \
                iproute2 can-utils \
                vim tmux \
-               build-essential git make gcc cmake cmake-curses-gui
+               build-essential git make gcc cmake cmake-curses-gui \
+               gettext
 
 ENV LANG en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
@@ -43,6 +44,7 @@ RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
 
 WORKDIR /signalbroker
 COPY --from=build-env signalbroker/_build /signalbroker/_build/
+COPY --from=build-env /usr/bin/envsubst /usr/bin/envsubst
 COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,5 +47,6 @@ COPY --from=build-env signalbroker/_build /signalbroker/_build/
 COPY --from=build-env /usr/bin/envsubst /usr/bin/envsubst
 COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
+ENV SIGNAL_SERVER /signalbroker/_build/prod/rel/signal_server
 
 ENTRYPOINT ["_build/prod/rel/signal_server/bin/signal_server", "console"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,10 +41,9 @@ RUN apt-get update \
 ENV LANG en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
 
-WORKDIR /signalbroker/_build/prod/rel/signal_server
 COPY --from=build-env signalbroker/_build /signalbroker/_build/
 COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
-ENV SIGNAL_SERVER /signalbroker/_build/prod/rel/signal_server
+WORKDIR /signalbroker/_build/prod/rel/signal_server
 
 CMD [ "./bin/signal_server", "console" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,8 +42,8 @@ ENV LANG en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
 
 WORKDIR /signalbroker
+COPY --from=build-env signalbroker/_build /signalbroker/_build/
+COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
-COPY --from=build-env signalbroker/_build ./_build/
-COPY --from=build-env signalbroker/configuration ./_build/prod/rel/signal_server/configuration/
 
 ENTRYPOINT ["_build/prod/rel/signal_server/bin/signal_server", "console"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,11 +42,11 @@ RUN apt-get update \
 ENV LANG en_US.UTF-8
 RUN echo "en_US.UTF-8 UTF-8" >/etc/locale.gen && locale-gen
 
-WORKDIR /signalbroker
+WORKDIR /signalbroker/_build/prod/rel/signal_server
 COPY --from=build-env signalbroker/_build /signalbroker/_build/
 COPY --from=build-env /usr/bin/envsubst /usr/bin/envsubst
 COPY configuration /signalbroker/_build/prod/rel/signal_server/configuration
 
 ENV SIGNAL_SERVER /signalbroker/_build/prod/rel/signal_server
 
-ENTRYPOINT ["_build/prod/rel/signal_server/bin/signal_server", "console"]
+CMD [ "./bin/signal_server", "console" ]


### PR DESCRIPTION
Idea to use docker-compose to simplify the start of the signal server. There are two docker-compose config files: one for linux (the default one) and one for mac.