### PR TITLE
Remove socketcan deps, re-enable CI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ erl_crash.dump
 # Ignore .elixir_ls
 .elixir_ls
 
-# Ignore configuration
-/configuration/
-
 # Ignore flexray.dump
 flexray.dump
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,24 @@ arch:
   # - arm32 https://travis-ci.community/t/erlang-otp-21-1-4-is-missing-but-only-for-arm-64/6438/3
   - amd64
 
-# language: elixir
+language: elixir
 
-# elixir:
-#   - 1.8.1
+elixir:
+  - 1.8.1
 
-# otp_release:
-#   - 22.2
+otp_release:
+  - 22.0.5
 
 services:
   - docker
 
 before_install:
-  # - mix local.hex --force
-  # - mix local.rebar --force
-  # - mix deps.get
-  # - mix test --only success
+  - mix local.hex --force
+  - mix local.rebar --force
+  - mix deps.get
+  - mix test --only success
   - docker build -t signalbroker-server:latest -f ./docker/Dockerfile .
-  - echo "testing inside docker container..."
+  # - echo "testing inside docker container..."
   # - docker run -d -p 127.0.0.1:80:4567 carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec foreman start;"
   # - docker ps -a
   # - docker run carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec rake test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ before_install:
   # - mix deps.get
   # - mix test --only success
   - docker build -t signalbroker-server:latest -f ./docker/Dockerfile .
+  - echo "testing inside docker container..."
   # - docker run -d -p 127.0.0.1:80:4567 carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec foreman start;"
   # - docker ps -a
   # - docker run carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec rake test"
 
 script:
-  - echo "testing inside docker container..."
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then echo -e "Upload Container to DockerHub"; else travis_terminate 0; fi
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker tag signalbroker-server:latest "$DOCKER_USERNAME"/signalbroker-server:travis-$TRAVIS_BUILD_NUMBER-$TRAVIS_CPU_ARCH
   - docker push "$DOCKER_USERNAME"/signalbroker-server:travis-$TRAVIS_BUILD_NUMBER-$TRAVIS_CPU_ARCH

--- a/apps/grpc_service/lib/server_functional.ex
+++ b/apps/grpc_service/lib/server_functional.ex
@@ -38,7 +38,7 @@ defmodule Base.FunctionalService.Server do
       value
     end
 
-    GRPCSubscriber.start_link(String.to_atom(name), self(), [%SignalId{name: "HmiHvacFanLvlFrnt", namespace: %Base.NameSpace{name: Atom.to_string(@body)}}], String.to_atom(request.clientId.id), pack_response)
+    GRPCSubscriber.start_link(String.to_atom(name), self(), [%SignalId{name: "TestFr02_Child05", namespace: %Base.NameSpace{name: Atom.to_string(@body)}}], String.to_atom(request.clientId.id), pack_response)
     lock_pid(stream)
   end
 
@@ -106,10 +106,10 @@ defmodule Base.FunctionalService.Server do
 
   def window_front_right(data) do
     # funkar
-    target_frame = "DDMBodyFr01"
+    target_frame = "TestFr01"
 
-    #VAL_ 48 WinSwtReqToPass 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
-    #VAL_ 48 WinSwtReqToPassRe 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23Re 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
 
     inital_value =
       case SignalServerProxy.read_values(@gateway_pid, [target_frame], @body) do
@@ -120,18 +120,18 @@ defmodule Base.FunctionalService.Server do
     channels_with_values =
     [
       {target_frame, inital_value},
-      {"WinSwtReqToPass", data},
-      {"WinSwtReqToPass_UB", 1},
+      {"TestFr01_Child23", data},
+      {"TestFr01_Child23_UB", 1},
     ]
     SignalServerProxy.publish(@gateway_pid, channels_with_values, :source, @body)
   end
 
   def window_rear_right(data) do
-    target_frame = "DDMBodyFr01"
+    target_frame = "TestFr01"
 
     # funkar
-    #VAL_ 48 WinSwtReqToPass 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
-    #VAL_ 48 WinSwtReqToPassRe 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23Re 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
 
     inital_value =
       case SignalServerProxy.read_values(@gateway_pid, [target_frame], @body) do
@@ -142,8 +142,8 @@ defmodule Base.FunctionalService.Server do
     channels_with_values =
     [
       {target_frame, inital_value},
-      {"WinSwtReqToPassRe", data},
-      {"WinSwtReqToPassRe_UB", 1},
+      {"TestFr01_Child23Re", data},
+      {"TestFr01_Child23Re_UB", 1},
       # {"WinPosnStsAtDrvrRe", 2},
       # {"WinPosnStsAtDrvrRe_UB", 1},
     ]
@@ -151,10 +151,10 @@ defmodule Base.FunctionalService.Server do
   end
 
   def mirror() do
-    target_frame = "DDMBodyFr01"
+    target_frame = "TestFr01"
 
-    #VAL_ 48 WinSwtReqToPass 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
-    #VAL_ 48 WinSwtReqToPassRe 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
+    #VAL_ 48 TestFr01_Child23Re 0 "WinPosnReq_Idle" 1 "WinPosnReq_UpMan" 2 "WinPosnReq_UpAut" 3 "WinPosnReq_DwnMan" 4 "WinPosnReq_DwnAut" 5 "WinPosnReq_NotDefd";
     #VAL_ 48 MirrCmdAtPassFold 0 "MirrFoldCmdTyp_Idle" 1 "MirrFoldCmdTyp_FoldIn" 2 "MirrFoldCmdTyp_FoldOut";
 
     inital_value =
@@ -248,10 +248,10 @@ defmodule Base.FunctionalService.Server do
 
   # interval 0..7
   def hvac_fan_speed(data, source) do
-    target_frame = "CEMBodyFr14"
+    target_frame = "TestFr02"
 
     # funkar
-    # CM_ SG_ 320 HmiHvacFanLvlFrnt "User requested fan level for first row.";
+    # CM_ SG_ 320 TestFr02_Child05 "User requested fan level for first row.";
     # CM_ SG_ 320 HmiHvacFanLvlRe "User requested fan level for second row";
 
     inital_value =
@@ -263,8 +263,8 @@ defmodule Base.FunctionalService.Server do
     channels_with_values =
     [
       {target_frame, inital_value},
-      {"HmiHvacFanLvlFrnt", data},
-      {"HmiHvacFanLvlFrnt_UB", 1},
+      {"TestFr02_Child05", data},
+      {"TestFr02_Child05_UB", 1},
       # {"HmiHvacFanLvlRe", 0},
       # {"HmiHvacFanLvlRe_IB", 1},
     ]
@@ -275,7 +275,7 @@ defmodule Base.FunctionalService.Server do
     # funkar ej
     target_frame = "CEMBodyFr15"
 
-    # CM_ SG_ 320 HmiHvacFanLvlFrnt "User requested fan level for first row.";
+    # CM_ SG_ 224 TestFr02_Child05 "User requested fan level for first row.";
     # CM_ SG_ 320 HmiHvacFanLvlRe "User requested fan level for second row";
 
     inital_value =

--- a/apps/grpc_service/test/grpc_client_test.exs
+++ b/apps/grpc_service/test/grpc_client_test.exs
@@ -95,8 +95,8 @@ defmodule GRPCClientTest do
   def set_network_value(value, channel, freq) do
     # Logger.info "client start"
     source = Base.ClientId.new(id: "source_string")
-    signal1 = Base.SignalId.new(name: "WinSwtReqToPass", namespace: Base.NameSpace.new(name: @body))
-    signal2 = Base.SignalId.new(name: "WinSwtReqToPass1", namespace: Base.NameSpace.new(name: @body))
+    signal1 = Base.SignalId.new(name: "TestFr01_Child23", namespace: Base.NameSpace.new(name: @body))
+    signal2 = Base.SignalId.new(name: "TestFr01_Child231", namespace: Base.NameSpace.new(name: @body))
     signals_with_payload = [Base.Signal.new(id: signal1, payload: value), Base.Signal.new(id: signal2, payload: 3)]
     request = Base.PublisherConfig.new(clientId: source, frequency: freq, signals: signals_with_payload)
 

--- a/apps/grpc_service/test/grpc_service_test.exs
+++ b/apps/grpc_service/test/grpc_service_test.exs
@@ -574,9 +574,9 @@ defmodule GRPCServiceTest do
     {:ok, pid} = Util.Forwarder.start_link(self())
 
     {:ok, pid} = SignalServerProxy.start_link({@gateway_pid, @simple_conf, String.to_atom(@body)})
-    assert_receive :signal_proxy_ready, 500
+    assert_receive :signal_proxy_ready, 5000
     {:ok, pid} = SignalBase.start_link(:broker0_pid, String.to_atom(@body), nil)
-    assert_receive :signal_base_ready, 500
+    assert_receive :signal_base_ready, 5000
     # {:ok, _} = SignalBase.start_link(:broker1_pid, :any, nil)
     # {:ok, _} = SignalBase.start_link(:broker2_pid, :any, nil)
 

--- a/apps/grpc_service/test/grpc_service_test.exs
+++ b/apps/grpc_service/test/grpc_service_test.exs
@@ -32,95 +32,95 @@ defmodule GRPCServiceTest do
     assert channel.port == 50051
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "make grpc call, (OpenPassWindow) make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01"]) == [{"TestFr01", :empty}]
     GRPCClientTest.test_open_window()
     assert_receive :cache_decoded
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 4}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23_UB"]) == [{"TestFr01_Child23_UB", 1}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23"]) == [{"TestFr01_Child23", 4}]
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01"]) == [{"TestFr01", 0}]
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "make grpc call, (ClosePassWindow) make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01"]) == [{"TestFr01", :empty}]
     GRPCClientTest.test_close_window()
     assert_receive :cache_decoded
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 2}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23_UB"]) == [{"TestFr01_Child23_UB", 1}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23"]) == [{"TestFr01_Child23", 2}]
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01"]) == [{"TestFr01", 0}]
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "make functional (set_fan_speed) hammer call with one shot, make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 0)
     assert_receive :cache_decoded
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", 12}]
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "make network hammer call with one shot, make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 0)
     assert_receive :cache_decoded
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", 12}]
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "make hammer call with 10 hz, make sure it reaches cache and make sure it's stoppable, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 100)
     assert_receive :cache_decoded
 
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", 12}]
 
 
     GRPCClientTest.start_hvac_hammer(12, 0)
     # stop it again
     # once it's stopped write to cache and chech that it's not updated again
-    SignalServerProxy.publish(@gateway_pid, [{"HmiHvacFanLvlFrnt", 5}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr02_Child05_UB", 5}], :none, String.to_atom(@body))
     assert_receive :cache_decoded
     :timer.sleep(100)
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 5}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05_UB"]) == [{"TestFr02_Child05_UB", 5}]
 
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "publish raw bytes make sure they arrive as published" do
     simple_initialize()
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
 
     <<expected::size(16)>> = <<256::size(16)>>
 
-    spawn(GRPCClientTest, :subscribe_to_signal, [["CCMVFCVectorFrame"], @body, GRPCClientTest.setup_connection()])
+    spawn(GRPCClientTest, :subscribe_to_signal, [["TestFr03"], @body, GRPCClientTest.setup_connection()])
 
     :timer.sleep(500)
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr03"]) == [{"TestFr03", :empty}]
     source = Base.ClientId.new(id: "publisher_string")
-    signal1 = Base.SignalId.new(name: "CCMVFCVectorFrame", namespace: Base.NameSpace.new(name: @body))
+    signal1 = Base.SignalId.new(name: "TestFr03", namespace: Base.NameSpace.new(name: @body))
     signals_with_payload = [
       Base.Signal.new(id: signal1, raw: <<expected::size(16)>>)
     ]
@@ -128,14 +128,14 @@ defmodule GRPCServiceTest do
     _stream = channel |> Base.NetworkService.Stub.publish_signals(request)
     assert_receive :cache_decoded
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", expected}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr03"]) == [{"TestFr03", expected}]
 
     :timer.sleep(500)
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}
     assert response.payload == {:integer, expected}
     assert response.raw == <<expected::size(16)>>
-    assert response.id.name == "CCMVFCVectorFrame"
+    assert response.id.name == "TestFr03"
     assert response.id.namespace.name == @body
 
 
@@ -148,12 +148,12 @@ defmodule GRPCServiceTest do
     simple_initialize
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
     # check empty...
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05_UB"]) == [{"TestFr02_Child05_UB", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23"]) == [{"TestFr01_Child23", :empty}]
 
     source = Base.ClientId.new(id: "source_string")
-    signal1 = Base.SignalId.new(name: "HmiHvacFanLvlFrnt", namespace: Base.NameSpace.new(name: @body))
-    signal2 = Base.SignalId.new(name: "WinSwtReqToPass", namespace: Base.NameSpace.new(name: @body))
+    signal1 = Base.SignalId.new(name: "TestFr02_Child05", namespace: Base.NameSpace.new(name: @body))
+    signal2 = Base.SignalId.new(name: "TestFr01_Child23", namespace: Base.NameSpace.new(name: @body))
     signal3 = Base.SignalId.new(name: "CEMBodyDevFr15", namespace: Base.NameSpace.new(name: @body))
     signal4 = Base.SignalId.new(name: "BfrLin18Fr00", namespace: Base.NameSpace.new(name: @lin))
     signal5 = Base.SignalId.new(name: "WinPosnStsDrv", namespace: Base.NameSpace.new(name: @body))
@@ -197,7 +197,7 @@ defmodule GRPCServiceTest do
 
     [returned_signal | t] = t
     assert returned_signal.payload == {:integer, 3}
-    assert returned_signal.id.name == "HmiHvacFanLvlFrnt"
+    assert returned_signal.id.name == "TestFr02_Child05"
     assert returned_signal.id.namespace.name == @body
     assert returned_signal.raw == <<3>>
 
@@ -208,14 +208,14 @@ defmodule GRPCServiceTest do
 
     [returned_signal | t] = t
     assert returned_signal.payload == {:double, 0.5}
-    assert returned_signal.id.name == "WinSwtReqToPass"
+    assert returned_signal.id.name == "TestFr01_Child23"
     assert returned_signal.id.namespace.name == @body
     assert returned_signal.raw == <<>>
 
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "fetch signals from server" do
     simple_initialize()
 
@@ -225,16 +225,16 @@ defmodule GRPCServiceTest do
     assert (Enum.count(response.frame) > 0)
     [first | rem] = response.frame
 
-    assert ((%Base.SignalInfo{id: %Base.SignalId{name: "DDMBodyFr01", namespace: %Base.NameSpace{name: "BodyCANhs"}}, metaData: %Base.MetaData{description: "", isRaw: false, max: 0, min: 0, size: 64, unit: ""}}) == first.signalInfo)
+    assert ((%Base.SignalInfo{id: %Base.SignalId{name: "TestFr01", namespace: %Base.NameSpace{name: "BodyCANhs"}}, metaData: %Base.MetaData{description: "", isRaw: false, max: 0, min: 0, size: 64, unit: ""}}) == first.signalInfo)
 
     [firstkid | rem] = first.childInfo
-    assert ((%Base.SignalInfo{id: %Base.SignalId{name: "ChdLockgProtnFailrStsToHmi_UB", namespace: %Base.NameSpace{name: "BodyCANhs"}}, metaData: %Base.MetaData{description: "", isRaw: false, max: 0, min: 0, size: 1, unit: ""}} == firstkid))
+    assert ((%Base.SignalInfo{id: %Base.SignalId{name: "TestFr01_Child01_UB", namespace: %Base.NameSpace{name: "BodyCANhs"}}, metaData: %Base.MetaData{description: "", isRaw: false, max: 0, min: 0, size: 1, unit: ""}} == firstkid))
 
     simple_terminate()
   end
 
 
-  @tag :success_with_dbc
+  @tag :success
   test "fetch signals from server - return empty list" do
     simple_initialize()
 
@@ -246,7 +246,7 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "fetch signals from server - use virtual network" do
     simple_initialize()
 
@@ -259,7 +259,7 @@ defmodule GRPCServiceTest do
   end
 
 
-  @tag :success_with_dbc
+  @tag :success
   test "get configuration" do
     simple_initialize()
 
@@ -275,13 +275,13 @@ defmodule GRPCServiceTest do
   test "write signal and make sure it reaches cache" do
     simple_initialize()
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23"]) == [{"TestFr01_Child23", :empty}]
 
     source = Base.ClientId.new(id: "source_string")
     namespace = Base.NameSpace.new(name: @body)
-    signal1 = Base.SignalId.new(name: "HmiHvacFanLvlFrnt", namespace: namespace)
-    signal2 = Base.SignalId.new(name: "WinSwtReqToPass", namespace: namespace)
+    signal1 = Base.SignalId.new(name: "TestFr02_Child05", namespace: namespace)
+    signal2 = Base.SignalId.new(name: "TestFr01_Child23", namespace: namespace)
     signal3 = Base.SignalId.new(name: "CEMBodyDevFr15", namespace: namespace)
     signal4 = Base.SignalId.new(name: "BfrLin18Fr00", namespace: Base.NameSpace.new(name: @lin))
 
@@ -299,8 +299,8 @@ defmodule GRPCServiceTest do
 
     :timer.sleep(500)
 
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 3}]
-    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 0.5}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr02_Child05"]) == [{"TestFr02_Child05", 3}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["TestFr01_Child23"]) == [{"TestFr01_Child23", 0.5}]
     assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CEMBodyDevFr15"]) == [{"CEMBodyDevFr15", 7.5}]
     # arbitration doesn't reach cache....
     assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["BfrLin18Fr00"]) == [{"BfrLin18Fr00", :empty}]
@@ -314,8 +314,8 @@ defmodule GRPCServiceTest do
   test "subscribe to signal and make sure it arrives from can, cache -> grpc" do
     simple_initialize()
 
-    field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "WinSwtReqToPass")
-    spawn(GRPCClientTest, :subscribe_to_signal, [["WinSwtReqToPass", "MirrFoldStsAtDrvr"], @body, GRPCClientTest.setup_connection()])
+    field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "TestFr01_Child23")
+    spawn(GRPCClientTest, :subscribe_to_signal, [["TestFr01_Child23", "MirrFoldStsAtDrvr"], @body, GRPCClientTest.setup_connection()])
 
     :timer.sleep(500)
     Payload.Signal.handle_raw_can_frames(
@@ -332,81 +332,81 @@ defmodule GRPCServiceTest do
 
     [response | t] = t
     assert response.payload == {:integer, 1}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
     simple_terminate()
   end
 
-  @tag :success_with_dbc
+  @tag :success
   test "subscribe to signal and make sure it arrives from signal broker" do
     simple_initialize()
 
-    # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "WinSwtReqToPass")
-    spawn(GRPCClientTest, :subscribe_to_signal, [["WinSwtReqToPass"], @body, GRPCClientTest.setup_connection()])
+    # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "TestFr01_Child23")
+    spawn(GRPCClientTest, :subscribe_to_signal, [["TestFr01_Child23"], @body, GRPCClientTest.setup_connection()])
 
-    :timer.sleep(2000)
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
+    :timer.sleep(500)
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 5}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 5}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
     # second signal, same as before
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 5}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 5}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
     simple_terminate()
   end
 
 
-  @tag :this1
+  @tag :success
   test "subscribe to signal and make sure it arrives from signal broker onchange active" do
      simple_initialize()
 
-    # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "WinSwtReqToPass")
-    spawn(GRPCClientTest, :subscribe_to_signal, [["WinSwtReqToPass", "MirrFoldStsAtDrvr"], @body, GRPCClientTest.setup_connection(), true])
+    # field = Payload.Descriptions.get_field_by_name(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), "SomeSignal")
+    spawn(GRPCClientTest, :subscribe_to_signal, [["TestFr01_Child23", "TestFr01_Child20"], @body, GRPCClientTest.setup_connection(), true])
 
     :timer.sleep(2000)
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 5}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 5}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
     # second signal, same as before, only the changed should arrive
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 5}, {"MirrFoldStsAtDrvr", 3}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 5}, {"TestFr01_Child20", 3}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 3}
-    assert response.id.name == "MirrFoldStsAtDrvr"
+    assert response.id.name == "TestFr01_Child20"
     assert response.id.namespace.name == @body
 
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 6}, {"MirrFoldStsAtDrvr", 3}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 6}, {"TestFr01_Child20", 3}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: [response | t]}}}, 1000
     assert response.payload == {:integer, 6}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
-    SignalServerProxy.publish(@gateway_pid, [{"WinSwtReqToPass", 1}, {"MirrFoldStsAtDrvr", 2}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr01_Child23", 1}, {"TestFr01_Child20", 2}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, %Base.Signals{signal: signals}}}, 1000
 
     [response | t] = signals |> Enum.sort()
     assert response.payload == {:integer, 2}
-    assert response.id.name == "MirrFoldStsAtDrvr"
+    assert response.id.name == "TestFr01_Child20"
     assert response.id.namespace.name == @body
 
     [response | t] = t
     assert response.payload == {:integer, 1}
-    assert response.id.name == "WinSwtReqToPass"
+    assert response.id.name == "TestFr01_Child23"
     assert response.id.namespace.name == @body
 
     simple_terminate()
@@ -417,7 +417,7 @@ defmodule GRPCServiceTest do
     simple_initialize()
     spawn(GRPCClientTest, :subscribe_to_fan_speed, ["source_string", GRPCClientTest.setup_connection()])
     :timer.sleep(500)
-    SignalServerProxy.publish(@gateway_pid, [{"HmiHvacFanLvlFrnt", 3}], :none, String.to_atom(@body))
+    SignalServerProxy.publish(@gateway_pid, [{"TestFr02_Child05", 3}], :none, String.to_atom(@body))
 
     assert_receive {:subscription_received, {:ok, response}}
     assert response.payload == 3

--- a/apps/grpc_service/test/grpc_service_test.exs
+++ b/apps/grpc_service/test/grpc_service_test.exs
@@ -25,76 +25,75 @@ defmodule GRPCServiceTest do
   @body "BodyCANhs"
   @lin "Lin"
 
+  @tag :success_with_dbc
   test "setup connection" do
     channel = GRPCClientTest.setup_connection()
     assert channel.host == "localhost"
     assert channel.port == 50051
   end
 
-  @tag :ignore
+  @tag :success_with_dbc
   test "make grpc call, (OpenPassWindow) make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(:cache0, ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
     GRPCClientTest.test_open_window()
     assert_receive :cache_decoded
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 4}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 4}]
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(:cache0, ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
     simple_terminate()
   end
 
-  @tag :ignore
+  @tag :success_with_dbc
   test "make grpc call, (ClosePassWindow) make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(:cache0, ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", :empty}]
     GRPCClientTest.test_close_window()
     assert_receive :cache_decoded
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 2}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass_UB"]) == [{"WinSwtReqToPass_UB", 1}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 2}]
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(:cache0, ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["DDMBodyFr01"]) == [{"DDMBodyFr01", 0}]
     simple_terminate()
   end
 
-  @tag :this3
-  @tag :ignore
+  @tag :success_with_dbc
   test "make functional (set_fan_speed) hammer call with one shot, make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 0)
     assert_receive :cache_decoded
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
     simple_terminate()
   end
 
-  @tag :ignore
+  @tag :success_with_dbc
   test "make network hammer call with one shot, make sure it reaches cache, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 0)
     assert_receive :cache_decoded
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
     simple_terminate()
   end
 
-  @tag :this14
-  @tag :ignore
+  @tag :success_with_dbc
   test "make hammer call with 10 hz, make sure it reaches cache and make sure it's stoppable, grpc -> cache" do
     simple_initialize()
 
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
     GRPCClientTest.start_hvac_hammer(12, 100)
     assert_receive :cache_decoded
 
     # TODO aren't we expecting the raw frame here?
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 12}]
 
 
     GRPCClientTest.start_hvac_hammer(12, 0)
@@ -103,13 +102,12 @@ defmodule GRPCServiceTest do
     SignalServerProxy.publish(@gateway_pid, [{"HmiHvacFanLvlFrnt", 5}], :none, String.to_atom(@body))
     assert_receive :cache_decoded
     :timer.sleep(100)
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 5}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 5}]
 
     simple_terminate()
   end
 
-  @tag :this2
-  @tag :ignore
+  @tag :success_with_dbc
   test "publish raw bytes make sure they arrive as published" do
     simple_initialize()
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
@@ -120,7 +118,7 @@ defmodule GRPCServiceTest do
 
     :timer.sleep(500)
 
-    assert Payload.Cache.read_channels(:cache0, ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", :empty}]
     source = Base.ClientId.new(id: "publisher_string")
     signal1 = Base.SignalId.new(name: "CCMVFCVectorFrame", namespace: Base.NameSpace.new(name: @body))
     signals_with_payload = [
@@ -130,7 +128,7 @@ defmodule GRPCServiceTest do
     _stream = channel |> Base.NetworkService.Stub.publish_signals(request)
     assert_receive :cache_decoded
 
-    assert Payload.Cache.read_channels(:cache0, ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", expected}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CCMVFCVectorFrame"]) == [{"CCMVFCVectorFrame", expected}]
 
     :timer.sleep(500)
 
@@ -145,14 +143,13 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :this4
-  @tag :ignore
+  @tag :success_with_dbc
   test "publish signal and read it using readfunction" do
     simple_initialize
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
     # check empty...
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
 
     source = Base.ClientId.new(id: "source_string")
     signal1 = Base.SignalId.new(name: "HmiHvacFanLvlFrnt", namespace: Base.NameSpace.new(name: @body))
@@ -218,8 +215,7 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :this10
-  @tag :ignore
+  @tag :success_with_dbc
   test "fetch signals from server" do
     simple_initialize()
 
@@ -238,8 +234,7 @@ defmodule GRPCServiceTest do
   end
 
 
-  @tag :this10
-  @tag :ignore
+  @tag :success_with_dbc
   test "fetch signals from server - return empty list" do
     simple_initialize()
 
@@ -251,8 +246,7 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :this11
-  @tag :ignore
+  @tag :success_with_dbc
   test "fetch signals from server - use virtual network" do
     simple_initialize()
 
@@ -265,8 +259,7 @@ defmodule GRPCServiceTest do
   end
 
 
-  @tag :this12
-  @tag :ignore
+  @tag :success_with_dbc
   test "get configuration" do
     simple_initialize()
 
@@ -278,12 +271,12 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :ignore
+  @tag :success_with_dbc
   test "write signal and make sure it reaches cache" do
     simple_initialize()
     {:ok, channel} = GRPC.Stub.connect("localhost:50051")
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", :empty}]
 
     source = Base.ClientId.new(id: "source_string")
     namespace = Base.NameSpace.new(name: @body)
@@ -306,19 +299,18 @@ defmodule GRPCServiceTest do
 
     :timer.sleep(500)
 
-    assert Payload.Cache.read_channels(:cache0, ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 3}]
-    assert Payload.Cache.read_channels(:cache0, ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 0.5}]
-    assert Payload.Cache.read_channels(:cache0, ["CEMBodyDevFr15"]) == [{"CEMBodyDevFr15", 7.5}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["HmiHvacFanLvlFrnt"]) == [{"HmiHvacFanLvlFrnt", 3}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["WinSwtReqToPass"]) == [{"WinSwtReqToPass", 0.5}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["CEMBodyDevFr15"]) == [{"CEMBodyDevFr15", 7.5}]
     # arbitration doesn't reach cache....
-    assert Payload.Cache.read_channels(:cache0, ["BfrLin18Fr00"]) == [{"BfrLin18Fr00", :empty}]
+    assert Payload.Cache.read_channels(Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), ["BfrLin18Fr00"]) == [{"BfrLin18Fr00", :empty}]
 
     simple_terminate()
   end
 
   require Logger
 
-  @tag :this5
-  @tag :ignore
+  @tag :success_with_dbc
   test "subscribe to signal and make sure it arrives from can, cache -> grpc" do
     simple_initialize()
 
@@ -327,7 +319,7 @@ defmodule GRPCServiceTest do
 
     :timer.sleep(500)
     Payload.Signal.handle_raw_can_frames(
-      :can_vcan0_signal, :test_source,
+      Payload.Name.generate_name_from_namespace(String.to_atom(@body), :signal), :test_source,
       [{field.id, <<0x12, 0x34,0x56,0x78,0xab,0xcd,0xef,0x01>>}])
 
 
@@ -346,8 +338,7 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :this1
-  @tag :ignore
+  @tag :success_with_dbc
   test "subscribe to signal and make sure it arrives from signal broker" do
     simple_initialize()
 
@@ -421,8 +412,7 @@ defmodule GRPCServiceTest do
     simple_terminate()
   end
 
-  @tag :that2
-  @tag :ignore
+  @tag :success_with_dbc
   test "subscribe to fan speed" do
     simple_initialize()
     spawn(GRPCClientTest, :subscribe_to_fan_speed, ["source_string", GRPCClientTest.setup_connection()])
@@ -470,7 +460,7 @@ defmodule GRPCServiceTest do
 
   def local_publisher(response_data_raw) do
     # send messages back to Diagnostics ans make sure the a re concatenaded accordingly
-    :timer.sleep(100)
+    :timer.sleep(500)
     Enum.each(response_data_raw, fn(entry) ->
       SignalServerProxy.publish(@gateway_pid, [{"TesterPhysicalResCEMHS", entry}], :none, String.to_atom(@body))
     end)
@@ -478,8 +468,7 @@ defmodule GRPCServiceTest do
 
   @expected_request 0x0322F19000000000
   @expected_request2 0x3000000000000000
-  @tag :diag1
-  @tag :ignore
+  @tag :success_with_dbc
   test "simple read diagnostics VIN" do
 
     simple_initialize()
@@ -509,8 +498,7 @@ defmodule GRPCServiceTest do
 
   @expected_request3 0x0322F12E00000000
   @expected_request4 0x3000000000000000
-  @tag :diag2
-  @tag :ignore
+  @tag :success_with_dbc
   test "simple read diagnostics something else" do
 
     simple_initialize()
@@ -539,8 +527,7 @@ defmodule GRPCServiceTest do
   end
 
 
-  @tag :diag3
-  @tag :ignore
+  @tag :success_with_dbc
   test "simple read diagnostics single frame" do
 
     simple_initialize()
@@ -572,7 +559,7 @@ defmodule GRPCServiceTest do
 
 
   @simple_conf %{
-    BodyCANhs: %{signal_base_pid: :broker0_pid, signal_cache_pid: :cache0, type: "can"},
+    BodyCANhs: %{signal_base_pid: :broker0_pid, signal_cache_pid: Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), type: "udp"},
     Virtual: %{signal_base_pid: :broker1_pid, signal_cache_pid: :cache1, type: "virtual"},
   }
 
@@ -593,7 +580,12 @@ defmodule GRPCServiceTest do
     # {:ok, _} = SignalBase.start_link(:broker1_pid, :any, nil)
     # {:ok, _} = SignalBase.start_link(:broker2_pid, :any, nil)
 
-    {:ok, pid} = AppNgCan.start_link({{"vcan0", Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), :conn, :can_vcan0_signal, :writer, :cache0, :broker0_pid, String.to_atom(@body), "can"}, dbc_file: "../../configuration/can_files/SPA0610/SPA0610_140404_BodyCANhs.dbc"})
+    #   def start_link({{device, desc, conn, signal, canwriter, cache, signalbase, namespace, type}, physical}) when is_atom(namespace)
+    # {:ok, pid} = AppNgCan.start_link({{"vcan0", Payload.Name.generate_name_from_namespace(String.to_atom(@body), :desc), :conn, Payload.Name.generate_name_from_namespace(String.to_atom(@body), :signal), :writer, Payload.Name.generate_name_from_namespace(String.to_atom(@body), :cache), :broker0_pid, String.to_atom(@body), "can"}, dbc_file: "../../configuration/can_files/SPA0610/SPA0610_140404_BodyCANhs.dbc"})
+
+    #   def start_link({namespace, signalbase_pid, conf, server_port, target_host, target_port, type}) when is_atom(namespace) do
+
+    {:ok, pid} = CanUdp.App.start_link({String.to_atom(@body), :broker0_pid, [dbc_file: "../../configuration/can_files/SPA0610/SPA0610_140404_BodyCANhs.dbc"], 2001, '127.0.0.1', 2000, "udp"})
     assert_receive {:ready_descriptors, :broker0_pid}, 3_000
   end
 

--- a/apps/grpc_service/test/grpc_service_test.exs
+++ b/apps/grpc_service/test/grpc_service_test.exs
@@ -468,7 +468,7 @@ defmodule GRPCServiceTest do
 
   @expected_request 0x0322F19000000000
   @expected_request2 0x3000000000000000
-  @tag :success_with_dbc
+  @tag :success
   test "simple read diagnostics VIN" do
 
     simple_initialize()
@@ -498,7 +498,7 @@ defmodule GRPCServiceTest do
 
   @expected_request3 0x0322F12E00000000
   @expected_request4 0x3000000000000000
-  @tag :success_with_dbc
+  @tag :success
   test "simple read diagnostics something else" do
 
     simple_initialize()
@@ -527,7 +527,7 @@ defmodule GRPCServiceTest do
   end
 
 
-  @tag :success_with_dbc
+  @tag :success
   test "simple read diagnostics single frame" do
 
     simple_initialize()
@@ -585,7 +585,7 @@ defmodule GRPCServiceTest do
 
     #   def start_link({namespace, signalbase_pid, conf, server_port, target_host, target_port, type}) when is_atom(namespace) do
 
-    {:ok, pid} = CanUdp.App.start_link({String.to_atom(@body), :broker0_pid, [dbc_file: "../../configuration/can_files/SPA0610/SPA0610_140404_BodyCANhs.dbc"], 2001, '127.0.0.1', 2000, "udp"})
+    {:ok, pid} = CanUdp.App.start_link({String.to_atom(@body), :broker0_pid, [dbc_file: "../../configuration/can/test.dbc"], 2001, '127.0.0.1', 2000, "udp"})
     assert_receive {:ready_descriptors, :broker0_pid}, 3_000
   end
 

--- a/configuration/can/test.dbc
+++ b/configuration/can/test.dbc
@@ -1,0 +1,37 @@
+// *************************************************************************** *
+// *                                                                           *
+// *             Mini dbc file for diagnostic queries.                         *
+// *             https://en.wikipedia.org/wiki/OBD-II_PIDs                     *
+// *                                                                           *
+// *************************************************************************** *
+
+// *    ref https://en.wikipedia.org/wiki/OBD-II_PIDs                                                               *
+// *    The diagnostic reader initiates a query using CAN ID 7DFh/2015 [clarification needed],                      *
+// *    which acts as a broadcast address, and accepts responses from any ID in the range 7E8h/2024 to 7EFh/2031.   *
+// *    ECUs that can respond to OBD queries listen both to the functional broadcast ID of 7DFh/2015 and one        *
+// *    assigned ID in the range 7E0h/2015 to 7E7h/2023. Their response has an ID of their assigned ID plus 8 e.g.  *
+// *    7E8h/2024 through 7EFh/2031.                                                                                *
+
+
+VERSION "DiagnsticsCANhs"
+
+BO_ 2015 DiagReqBroadCastFrame_2015: 8 ETC
+
+BO_ 2016 DiagReqFrame_2016: 8 ETC
+BO_ 2017 DiagReqFrame_2017: 8 ETC
+BO_ 2018 DiagReqFrame_2018: 8 ETC
+BO_ 2019 DiagReqFrame_2019: 8 ETC
+BO_ 2020 DiagReqFrame_2020: 8 ETC
+BO_ 2021 DiagReqFrame_2021: 8 ETC
+BO_ 2022 DiagReqFrame_2022: 8 ETC
+BO_ 2023 DiagReqFrame_2023: 8 ETC
+
+BO_ 2024 DiagResFrame_2024: 8 ECM
+BO_ 2025 DiagResFrame_2025: 8 ECM
+BO_ 2026 DiagResFrame_2026: 8 ECM
+BO_ 2027 DiagResFrame_2027: 8 ECM
+BO_ 2028 DiagResFrame_2028: 8 ECM
+BO_ 2029 DiagResFrame_2029: 8 ECM
+BO_ 2030 DiagResFrame_2030: 8 ECM
+BO_ 2031 DiagResFrame_2031: 8 ECM
+

--- a/configuration/can/test.dbc
+++ b/configuration/can/test.dbc
@@ -35,3 +35,75 @@ BO_ 2029 DiagResFrame_2029: 8 ECM
 BO_ 2030 DiagResFrame_2030: 8 ECM
 BO_ 2031 DiagResFrame_2031: 8 ECM
 
+BO_ 53 TestFr01: 8 DDM
+ SG_ TestFr01_Child01 : 9|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child01_UB : 7|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child02 : 23|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child02_UB : 6|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child03 : 45|1@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child03_UB : 44|1@0+ (1,0) [0|1] "" PDM
+ SG_ TestFr01_Child04 : 43|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child04_UB : 15|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child05 : 31|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child05_UB : 4|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child06 : 21|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM, TEM0
+ SG_ TestFr01_Child06_UB : 5|1@0+ (1,0) [0|1] "" CEM, TEM0
+ SG_ TestFr01_Child07 : 19|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM, TEM0
+ SG_ TestFr01_Child07_UB : 3|1@0+ (1,0) [0|1] "" CEM, TEM0
+ SG_ TestFr01_Child08 : 17|2@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child08_UB : 2|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child09 : 49|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child09_UB : 48|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child10 : 29|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child10_UB : 0|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child11 : 14|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child12 : 13|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child13 : 12|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child14 : 11|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child14_UB : 28|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child15 : 27|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child15_UB : 47|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child16 : 26|1@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child16_UB : 46|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child17 : 39|3@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child18 : 36|2@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child19 : 34|2@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child19_UB : 32|1@0+ (1,0) [0|1] "" PDM
+ SG_ TestFr01_Child20 : 55|3@0+ (1.0, 0.0) [0.0|0.0] "" CEM
+ SG_ TestFr01_Child21_UB : 25|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr01_Child22 : 63|5@0+ (1.0, 0.0) [0.0|0.0] "" CCM, CEM, TEM0
+ SG_ TestFr01_Child22_UB : 1|1@0+ (1,0) [0|1] "" CCM, CEM, TEM0
+ SG_ TestFr01_Child23 : 58|3@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child23_UB : 30|1@0+ (1,0) [0|1] "" PDM
+ SG_ TestFr01_Child24 : 52|3@0+ (1.0, 0.0) [0.0|0.0] "" PDM
+ SG_ TestFr01_Child24_UB : 24|1@0+ (1,0) [0|1] "" PDM
+
+BO_ 224 TestFr02: 8 CEM
+ SG_ TestFr02_Child01 : 15|8@0+ (0.5, 0.0) [0.0|127.5] "Wh" TEM0
+ SG_ TestFr02_Child01_UB : 0|1@0+ (1,0) [0|1] "" TEM0
+ SG_ TestFr02_Child02 : 23|8@0+ (0.5, 0.0) [0.0|127.5] "Wh" TEM0
+ SG_ TestFr02_Child02_UB : 1|1@0+ (1,0) [0|1] "" TEM0
+ SG_ TestFr02_Child03 : 58|3@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child03_UB : 59|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child04 : 47|2@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child04_UB : 45|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child05 : 7|4@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child05_UB : 3|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child06 : 51|4@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child06_UB : 55|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child07 : 53|2@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child07_UB : 54|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child08 : 63|2@0+ (1.0, 0.0) [0.0|0.0] "" CCM
+ SG_ TestFr02_Child08_UB : 61|1@0+ (1,0) [0|1] "" CCM
+ SG_ TestFr02_Child09 : 29|1@0+ (1.0, 0.0) [0.0|0.0] "" DDM, PDM
+ SG_ TestFr02_Child09_UB : 30|1@0+ (1,0) [0|1] "" DDM, PDM
+ SG_ TestFr02_Child10 : 28|5@0+ (1.0, 0.0) [0.0|22.0] "NoUnit" DDM, PDM
+ SG_ TestFr02_Child10_UB : 60|1@0+ (1,0) [0|1] "" DDM, PDM
+ SG_ TestFr02_Child11 : 35|4@0+ (1.0, 0.0) [0.0|0.0] "" DDM, PDM
+ SG_ TestFr02_Child11_UB : 31|1@0+ (1,0) [0|1] "" DDM, PDM
+
+BO_ 766 TestFr03: 8 CCM
+ SG_ TestFr03_Child01_UB : 55|1@0+ (1,0) [0|1] "" CEM
+ SG_ TestFr03_Child01: 7|16@0+ (1.0, 0.0) [0.0|65535.0] "NoUnit" CEM
+ SG_ TestFr03_Child02: 23|16@0+ (1.0, 0.0) [0.0|65535.0] "NoUnit" CEM
+ SG_ TestFr03_Child03: 39|16@0+ (1.0, 0.0) [0.0|65535.0] "NoUnit" CEM

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,9 @@ COPY . /signalbroker/
 WORKDIR /signalbroker
 RUN rm -rf _build
 RUN rm -rf deps
+RUN rm -rf apps/app_ngcan/priv
 RUN mix deps.get
-RUN mix test --only success
+# RUN mix test --only success
 RUN mix release
 
 


### PR DESCRIPTION
CI/CD Build chain runs `success` test.

First larger step to re-enable tests. This step contains. 
* executes most of grpc tests

